### PR TITLE
filter by category

### DIFF
--- a/app/assets/stylesheets/post/ads.scss
+++ b/app/assets/stylesheets/post/ads.scss
@@ -244,11 +244,31 @@ $orange: #ff5722;
     border-radius: 3px;
     .item-content {
       width: 100%;
+      padding: 0;
+      margin-bottom: 15px;
+      position: relative;
+      .ribbon {
+        display: block;
+        position: absolute;
+        bottom: 0;
+        width: 100%;
+        height: 20%;
+        background: rgba(0, 0, 0, 0.5);
+        color: white;
+        text-align: right;
+        padding: 5px 10px;
+        a {
+          color: white;
+        }
+      }
       .item-image {
         width: 100%;
         height: 160px;
         box-shadow: none;
         padding: 0;
+        &:hover {
+          opacity: 0.7;
+        }
       }
     }
     .item-info {
@@ -273,8 +293,14 @@ $orange: #ff5722;
       }
       .meta-tag {
         margin-top: 15px;
-        div {
+        .comment {
+          display: none;
+        }
+        span {
+          display: block;
+          width: 100%;
           text-align: right;
+          margin-right: 0;
         }
       }
     }
@@ -287,6 +313,9 @@ $orange: #ff5722;
   display: flex;
   margin-bottom: 5px;
   overflow: hidden;
+  .ribbon {
+    display: none;
+  }
 }
 
 .item-content{

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -36,8 +36,9 @@ class Post < ApplicationRecord
   }
 
   scope :filtered_by_mode_time_category, (lambda do |mode, time, id|
-    joins(:category).where("categories.parent_id": id, mode: mode).approved
-      .order created_at: time
+    joins(:category)
+      .where("categories.parent_id=? OR category_id=? AND mode=?", id, id, mode)
+      .approved.order created_at: time
   end)
   scope :by_domain, (lambda do |domain_id|
     where(domain_id: domain_id).or(where domain_id: nil)

--- a/app/views/ads/posts/_post.html.erb
+++ b/app/views/ads/posts/_post.html.erb
@@ -10,6 +10,21 @@
           <%= hidden_field_tag "post_images", image.image_url %>
         <% end %>
       <% end %>
+      <div class="ribbon">
+        <span class="created-at">
+          <i class="fa fa-clock-o">
+            <%= t("ads.post.created_at",
+              time: time_ago_in_words(post.created_at)).capitalize %>
+          </i>
+        </span> |
+        <span class="commented">
+          <i class="fa fa-comment">
+            <%= link_to domain_ads_post_path(domain_id: @domain, id: post) do %>
+              <%= pluralize post.reviews.size, t("ads.post.post.review") %>
+            <% end %>
+          </i>
+        </span>
+      </div>
     </div>
 
     <div class="col-md-10 item-info">
@@ -43,7 +58,7 @@
       </span>
 
       <div class="meta-tag row">
-        <div class="col-md-6">
+        <div class="col-md-6 comment">
           <span><i class="fa fa-comment">
             <%= link_to domain_ads_post_path(domain_id: @domain, id: post) do %>
               <%= pluralize post.reviews.size, t("ads.post.post.review") %>

--- a/app/views/ads/posts/index.html.erb
+++ b/app/views/ads/posts/index.html.erb
@@ -191,6 +191,12 @@
                 <% end %>
               </ul>
             </div>
+          <% else %>
+            <div class="col-md-2 domain-filter">
+              <button class="btn btn-default full-with" type="button">
+                <%= @domain.name %>
+              </button>
+            </div>
           <% end %>
 
           <div class="grid-option col-md-2">


### PR DESCRIPTION
Things done in this pull:
- Can filter ads posts by choosing sub-category or parent category.
- Change the grid view posts template a little
![grid-view-box](https://user-images.githubusercontent.com/20473844/42150854-4d8cfca2-7e05-11e8-829e-72bf457eb0ee.png)
- If user has just one default domain, it also display on filter bar but has no options to choose.
![one-domain](https://user-images.githubusercontent.com/20473844/42151131-24dddb22-7e06-11e8-8d81-0a5842ffd8aa.png)

