### PR TITLE
modify admin create category feature

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -53,4 +53,6 @@ $(document).ready(function () {
     $('.list-format').addClass('active');
     $('.ads-item-wrap').removeClass('grid-view');
   });
+
+  $('#category_parent_id option:first-child').val('0');
 });

--- a/app/assets/stylesheets/admin/categories.scss
+++ b/app/assets/stylesheets/admin/categories.scss
@@ -1,0 +1,25 @@
+$gray: #ccc;
+
+.common {
+  .accordion {
+    .badge {
+      float: left;
+      margin-right: 15px;
+      background-color: $gray;
+      color: black;
+      padding: 10px;
+    }
+    .category-name {
+      line-height: 2.5;
+    }
+    .panel {
+      border-bottom: none;
+    }
+    li:last-child {
+      border-bottom: 1px solid #ddd;
+    }
+    .btn-zero {
+      padding: 10px 15px;
+    }
+  }
+}

--- a/app/controllers/admin/categories_controller.rb
+++ b/app/controllers/admin/categories_controller.rb
@@ -1,12 +1,13 @@
 class Admin::CategoriesController < AdminController
   load_and_authorize_resource
+  before_action :load_categories, except: [:index, :destroy]
 
   def index
-    @categories = @categories.asc_by_name.page(params[:page])
-      .per Settings.common.per_page
+    @categories = Category.is_parent
   end
 
   def new
+    @default_category_id = params[:cate_id]
   end
 
   def create
@@ -20,6 +21,7 @@ class Admin::CategoriesController < AdminController
   end
 
   def edit
+    @default_category_id = @category.parent_id
   end
 
   def update
@@ -47,6 +49,10 @@ class Admin::CategoriesController < AdminController
 
   private
   def category_params
-    params.require(:category).permit :name
+    params.require(:category).permit :name, :parent_id
+  end
+
+  def load_categories
+    @categories = Category.all
   end
 end

--- a/app/views/admin/categories/_action_links.html.erb
+++ b/app/views/admin/categories/_action_links.html.erb
@@ -1,0 +1,9 @@
+<%= link_to t("common.create_sub"), new_admin_category_path(cate_id: category.id),
+  class: "btn btn-default" %>
+<%= link_to t("common.edit_button"),
+  edit_admin_category_path(category),
+  class: "btn btn-primary" %>
+<%= link_to t("common.delete_button"),
+  admin_category_path(category), method: :delete,
+  data: {confirm: t(".delete_confirm")},
+  class: "btn btn-danger" %>

--- a/app/views/admin/categories/_category.html.erb
+++ b/app/views/admin/categories/_category.html.erb
@@ -1,0 +1,41 @@
+<li class="list-group-item panel">
+  <% if category.subcategories.any? %>
+    <div class="row">
+      <div class="col-md-6">
+        <div id="<%= category.id %>"
+          class="panel-heading">
+          <span class="category-name"><%= category.name %></span>
+          <button class="badge btn" type="button" data-toggle="collapse"
+            data-parent="#accordion-cate-<%= local_assigns[:level] %>"
+            href="#accordion-cate-<%= category.id %>">
+            <%= category.subcategories.size %>
+            <span class="caret"></span>
+          </button>
+        </div>
+      </div>
+      <div class="col-md-6 text-right">
+        <%= render "action_links", category: category %>
+      </div>
+    </div>
+    <ul class="list-group panel-collapse collapse sub-list"
+      id="accordion-cate-<%= category.id %>"
+      aria-labelledby="<%= category.id %>">
+      <%= render partial: "category", collection: category.subcategories, as: :category,
+          locals: {level: category.id} %>
+    </ul>
+  <% else %>
+    <div class="row">
+      <div class="col-md-6">
+        <div class="panel-heading">
+          <span class="category-name"><%= category.name %></span>
+          <button class="badge btn btn-zero" type="button">
+            <%= category.subcategories.size %>
+          </button>
+        </div>
+      </div>
+      <div class="col-md-6 text-right">
+        <%= render "action_links", category: category %>
+      </div>
+    </div>
+  <% end %>
+</li>

--- a/app/views/admin/categories/_form.html.erb
+++ b/app/views/admin/categories/_form.html.erb
@@ -1,8 +1,17 @@
 <%= form_for [:admin, @category] do |f| %>
   <div class="form-group">
-    <%= f.label :name %>
+    <%= f.label :name, t(".name") %>
+    <span class="require">*</span>
     <%= f.text_field :name, class: "form-control" %>
   </div>
+
+  <div class="form-group">
+    <%= f.label :parent, t(".parent") %>
+    <%= f.collection_select :parent_id, @categories, :id, :name,
+      {include_blank: t("common.select"), selected: @default_category_id},
+      {class: "form-control"} %>
+  </div>
+
   <div class="row">
     <div class="col-md-6 text-center">
       <%= link_to t("common.back_button"), :back,

--- a/app/views/admin/categories/index.html.erb
+++ b/app/views/admin/categories/index.html.erb
@@ -2,44 +2,26 @@
 <div class="common">
   <div class="panel-heading">
     <div class="row text-center">
-      <div class="col-md-4">
-        <strong><%= t ".heading" %></strong>
-      </div>
-      <div class="col-md-4">
+      <div class="col-md-4 col-md-offset-8">
         <%= link_to t("common.create"), new_admin_category_path,
-          class: "btn btn-sm btn-success pull-right" %>
+          class: "btn btn-success pull-right" %>
       </div>
     </div>
   </div>
+  <div class="clearfix"></div>
 
   <div class="panel-body">
     <% if @categories.any? %>
-      <table class="table table-striped table-hover table-bordered">
-        <thead>
-          <tr>
-            <th><%= t "common.number" %></th>
-            <th><%= t ".name" %></th>
-            <th><%= t ".action" %></th>
-          </tr>
-        </thead>
-        <tbody>
-          <% @categories.each_with_index do |category, index| %>
-            <tr>
-              <td><%= increase_one index %></td>
-              <td><%= link_to category.name, category %></td>
-              <td>
-                <%= link_to t("common.edit_button"),
-                  edit_admin_category_path(category),
-                  class: "btn btn-primary" %>
-                <%= link_to t("common.delete_button"),
-                  admin_category_path(category), method: :delete,
-                  data: {confirm: t(".delete_confirm")},
-                  class: "btn btn-danger" %>
-              </td>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
+      <ul class="list-group accordion" id="accordion-cate-0">
+        <li class="list-group-item list-group-title">
+          <div class="panel-heading row">
+            <div class="col-md-6"><%= t ".name" %></div>
+            <div class="col-md-6 text-right"><%= t ".action" %></div>
+          </div>
+        </li>
+        <%= render partial: "category", collection: @categories, as: :category,
+          locals: {level: Settings.category.parent} %>
+      </ul>
     <% else %>
       <div><%= t ".no_categories" %></div>
     <% end %>

--- a/app/views/ads/posts/_category.html.erb
+++ b/app/views/ads/posts/_category.html.erb
@@ -7,16 +7,17 @@
         type: @post_support.filtered_param[:type],
         mode: @post_support.filtered_param[:mode]) %>
       <button class="badge btn" type="button" data-toggle="collapse"
-        data-parent="#accordion-<%= local_assigns[:div] %>"
-        href="#cate-<%= category.id %>-<%= local_assigns[:div] %>">
+        data-parent="#accordion-<%= local_assigns[:div] %>-cate-<%= local_assigns[:level] %>"
+        href="#accordion-<%= local_assigns[:div] %>-cate-<%= category.id %>">
         <%= category.subcategories_posts %>
         <span class="caret"></span>
       </button>
     </div>
     <ul class="list-group panel-collapse collapse sub-list"
-      id="cate-<%= category.id %>-<%= local_assigns[:div] %>"
+      id="accordion-<%= local_assigns[:div] %>-cate-<%= category.id %>"
       aria-labelledby="<%= category.id %>-<%= local_assigns[:div] %>">
-      <%= render partial: "category", collection: category.subcategories, as: :category %>
+      <%= render partial: "category", collection: category.subcategories, as: :category,
+        locals: {div: local_assigns[:div], level: category.id} %>
     </ul>
   <% else %>
     <%= link_to category.name, domain_ads_posts_path(@domain,

--- a/app/views/ads/posts/index.html.erb
+++ b/app/views/ads/posts/index.html.erb
@@ -13,12 +13,12 @@
   <div class="row">
     <div class="col-md-3 col-sm-12 col-xs-12">
       <div class="ads-post-categories">
-        <ul class="list-group accordion" id="accordion-aside">
+        <ul class="list-group accordion" id="accordion-aside-cate-0">
           <li class="list-group-item list-group-title">
             <h4><%= t "ads.post.index.categories" %></h4>
           </li>
           <%= render partial: "category", collection: @post_support.parent_categories,
-            as: :category, locals: {div: "aside"} %>
+            as: :category, locals: {div: "aside", level: Settings.category.parent} %>
         </ul>
       </div>
       <div class="most-review">
@@ -171,10 +171,10 @@
                     </h4>
                   </div>
                   <div class="modal-body">
-                    <ul class="list-group accordion" id="accordion-modal">
+                    <ul class="list-group accordion" id="accordion-modal-cate-0">
                       <%= render partial: "category",
-                        collection: @post_support.parent_categories,
-                        as: :category, locals: {div: "modal"} %>
+                        collection: @post_support.parent_categories, as: :category,
+                        locals: {div: "modal", level: Settings.category.parent} %>
                     </ul>
                   </div>
                 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -300,6 +300,9 @@ en:
     tags: "Tags"
     shop_managers: "Managers (%{num})"
     all_posts: "All posts"
+    create: "Create new"
+    create_sub: "Create sub-category"
+    select: "Select"
   header:
     account: "Account"
     shop_manager: "Shop manager"
@@ -419,6 +422,9 @@ en:
       edit:
         title: "Edit category"
         category: "Category"
+      form:
+        name: "Category's name"
+        parent: "Parent category"
     users:
       index:
         title: "All users"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -298,6 +298,9 @@ ja:
     tags: "カード"
     shop_managers: "管理 (%{num})"
     all_posts: "All posts"
+    create: "Create new"
+    create_sub: "Create sub-category"
+    select: "Select"
   header:
     account: "アカウント"
     shop_manager: "店長"
@@ -415,6 +418,9 @@ ja:
       edit:
         title: "編集"
         category: "カテゴリー"
+      form:
+        name: "Category's name"
+        parent: "Parent category"
     users:
       index:
         title: "すべてのユーザー"

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -344,6 +344,9 @@ vi:
     tags: "Thẻ"
     shop_managers: "Quản lý (%{num})"
     all_posts: "Tất cả bài đăng rao vặt"
+    create: "Tạo mới"
+    create_sub: "Tạo danh mục con"
+    select: "Chọn danh mục"
   header:
     account: "Tài khoản"
     shop_manager: "Quản lý cửa hàng"
@@ -463,6 +466,9 @@ vi:
       edit:
         title: "Chỉnh sửa"
         category: "Thể loại"
+      form:
+        name: "Tên thể loại"
+        parent: "Thể loại cha"
     users:
       index:
         title: "Tất cả người dùng"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -209,6 +209,7 @@ post:
     max_content: 90
 category:
   max_posts: 99
+  parent: "0"
 row_of_text: 10
 arenas:
   professed: "professed"


### PR DESCRIPTION
Things done in this pull:
- Modify index layout: display all category as tree view.
- Added create sub-category button for each category.
- Can choose parent category when create new category (option).

![admin-cate-index](https://user-images.githubusercontent.com/20473844/42298946-bfbcc6ca-8032-11e8-8e0d-c3864d3beeaf.png)
![admin-cate-new](https://user-images.githubusercontent.com/20473844/42298947-bff83dc2-8032-11e8-800d-1165a20dfb03.png)
